### PR TITLE
web version: fix sync issue in BlocklyEditorWidget init/build 

### DIFF
--- a/assets/dom_ready.js
+++ b/assets/dom_ready.js
@@ -1,0 +1,60 @@
+(function() {
+  function checkReady() {
+    const blocklyEditor = document.querySelector('#blocklyEditor');
+    const flutterWebView = window.FlutterWebView;
+    const blocklyEditorDefined = typeof editor !== 'undefined' && editor !== null;
+    
+    if (blocklyEditor && flutterWebView && blocklyEditorDefined) {
+      flutterWebView.postMessage(JSON.stringify({event: 'domReady', data: true}));
+      return true;
+    }
+    return false;
+  }
+  
+  function startChecking() {
+    // Try immediate check first
+    if (checkReady()) return;
+    
+    // Set up MutationObserver to watch for elements being added
+    var observer = new MutationObserver(() => {
+      if (checkReady()) {
+        observer.disconnect();
+        observer = null;
+      }
+    });
+    
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true
+    });
+    
+    // Also listen for load event in case elements exist but DOM isn't ready
+    window.addEventListener('load', () => {
+      if (checkReady()) {
+        observer.disconnect();
+        observer = null;
+      }
+    });
+    
+    // Fallback timeout after 10 seconds
+    setTimeout(() => {
+      if (observer !== null) {
+        observer.disconnect();
+        observer = null;
+        if (!checkReady() && window.FlutterWebView) {
+          window.FlutterWebView.postMessage(JSON.stringify({
+            event: 'onError', 
+            data: 'Timeout waiting for Blockly elements to be ready'
+          }));
+        }
+      }
+    }, 10000);
+  }
+  
+  // Wait for DOM to be at least interactive before starting
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', startChecking);
+  } else {
+    startChecking();
+  }
+})();

--- a/assets/html_script.js
+++ b/assets/html_script.js
@@ -87,6 +87,22 @@ const BlocklyEditor = () => {
       _toolboxConfig = null;
       _state = BlocklyState();
       _readOnly = false;
+      _code = {
+        dart: '',
+        js: '',
+        lua: '',
+        php: '',
+        python: '',
+      };      
+    }
+    // Clear and recreate the blocklyEditor element to ensure clean state
+    const element = document.querySelector('#blocklyEditor');
+    if (element) {
+      element.innerHTML = '';
+    }
+    const domReadyScript = document.querySelector('#domReadyScript');
+    if (domReadyScript) {
+      domReadyScript.remove();
     }
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,6 +22,8 @@ class WebViewApp extends StatefulWidget {
 }
 
 class _WebViewAppState extends State<WebViewApp> {
+  bool _isBlocklyVisible = true;
+
   // final BlocklyOptions workspaceConfiguration = BlocklyOptions(
   //   grid: const GridOptions(
   //     spacing: 20,
@@ -57,7 +59,7 @@ class _WebViewAppState extends State<WebViewApp> {
     'rendererOverrides': null,
     'rtl': null,
     'scrollbars': null,
-    'sounds': null,
+    'sounds': false,
     'theme': null,
     'toolboxPosition': null,
     'trashcan': null,
@@ -87,23 +89,33 @@ class _WebViewAppState extends State<WebViewApp> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: SafeArea(
-        child: BlocklyEditorWidget(
-          workspaceConfiguration: workspaceConfiguration,
-          initial: initialJson,
-          onInject: onInject,
-          onChange: onChange,
-          onDispose: onDispose,
-          onError: onError,
-          style: '.wrapper-web {top:58px;}',
-        ),
+        child: _isBlocklyVisible
+            ? BlocklyEditorWidget(
+                workspaceConfiguration: workspaceConfiguration,
+                initial: initialJson,
+                onInject: onInject,
+                onChange: onChange,
+                onDispose: onDispose,
+                onError: onError,
+                style: '.wrapper-web {top:58px;}',
+              )
+            : const Center(
+                child: Text('Click button to show editor'),
+              ),
       ),
       appBar: AppBar(
-        title: const Text('Title'),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {},
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
+        title: const Text('Blockly Editor Sample'),
+        actions: [
+          IconButton(
+            onPressed: () {
+              setState(() {
+                _isBlocklyVisible = !_isBlocklyVisible;
+              });
+            },
+            tooltip: _isBlocklyVisible ? 'Hide Blockly Editor' : 'Show Blockly Editor',
+            icon: Icon(_isBlocklyVisible ? Icons.close_outlined : Icons.add_box_outlined),
+          ),
+        ],
       ),
       bottomNavigationBar: const SizedBox(height: 50),
     );

--- a/lib/src/helpers/create_web_tag.dart
+++ b/lib/src/helpers/create_web_tag.dart
@@ -3,10 +3,12 @@ import 'package:web/web.dart' as web;
 /// cuts the tag from the string
 /// and creates a new html tag
 /// '<style>body{background: #fff}</style>'
-web.Element createWebTag({required String tag, String? content}) {
+web.Element createWebTag({required String tag, String? content, String? id}) {
   final web.Element element = web.document.createElement(tag);
   final String text = content?.replaceAll(RegExp('<$tag>|</$tag>'), '') ?? '';
   element.insertAdjacentText('afterbegin', text);
-
+  if (id != null) {
+    element.id = id;
+  }
   return element;
 }


### PR DESCRIPTION
The bug fixed that did not allow rebuilding editor on same page after disposal. Web version (did not try other one).
I do **not** specialize in JS/dart, so if there is a better solution will be happy to use it!

#### Details

See updated `main.dart` page with button to dispose/recreate the `BlocklyEditorWidget`. Before this fix recreating after removing did not work. 

The issue seem to be synchronization between `editor.init()` and DOM/JS building. First time it works because DOM/JS takes just the right time. Async `htmlRender` registers the view factory in time for `build()` to use it, and then takes time loading scripts and calls `editor.init()` **after** div `#blocklyEditor` was placed in DOM by `build()`. Second time `BlocklyEditorWidget` is initialized on the same page the scripts do not to be loaded (they are still already there), `htmlRender` ends faster and at `editor.init()` call there is no `#blocklyEditor` div yet - so workspace initialization does not happen.